### PR TITLE
Replace absolute paths

### DIFF
--- a/.github/workflows/deploy-swagger-to-pages.yml
+++ b/.github/workflows/deploy-swagger-to-pages.yml
@@ -2,8 +2,8 @@ name: Deploy Swagger to GitHub Pages
 
 on:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 
 jobs:
   generate-and-deploy-swagger:

--- a/.github/workflows/deploy-swagger-to-pages.yml
+++ b/.github/workflows/deploy-swagger-to-pages.yml
@@ -2,8 +2,8 @@ name: Deploy Swagger to GitHub Pages
 
 on:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 
 jobs:
   generate-and-deploy-swagger:

--- a/src/people/services/people.service.ts
+++ b/src/people/services/people.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { Person } from 'src/people/entities/person.entity';
-import { CreatePersonDto } from 'src/people/dto/create-person.dto';
+import { Person } from '../entities/person.entity';
+import { CreatePersonDto } from '../dto/create-person.dto';
 import { PeopleTransformService } from './people-transform.service';
-import { GetPersonDto } from 'src/people/dto/get-person.dto';
+import { GetPersonDto } from '../dto/get-person.dto';
 
 @Injectable()
 export class PeopleService {


### PR DESCRIPTION
Es necesario utilizar paths absolutos para que el codigo se ejecute correctamente en Github Actions.

Ejemplo del Swagger deploy en main fallando: https://github.com/WATERMELON-SA/ppaa-info-unlp/actions/runs/8825738854/job/24230401472

Ejemplo del deploy funcionando en esta rama: https://github.com/WATERMELON-SA/ppaa-info-unlp/actions/runs/8825784631/job/24230589565?pr=19